### PR TITLE
Use online status method update instead of updating database directly

### DIFF
--- a/src/schema/user/resolvers.js
+++ b/src/schema/user/resolvers.js
@@ -55,18 +55,9 @@ exports.Mutation = {
     await callMethodAtEndpoint('users.updateWorkspaceTime', { 'x-userid': user._id }, [{ workspaceId: workspace }]);
     return await Users.findOne({ _id: user._id });
   },
-  // 1. Always set to online when this method is called
-  // 2. Set to away/offline when there aren't any other open connections
-  updateUserOnlineStatus: async (root, { status }, { mongo: { Users, UsersSessions }, user }) => {
-    if (status === 'online') {
-      await Users.update({ _id: user._id }, { $set: { status, lastStatusChange: new Date() } });
-    } else {
-      const openSessions = await UsersSessions.findOne({ _id: user._id });
-      if (!openSessions) {
-        await Users.update({ _id: user._id }, { $set: { status, lastStatusChange: new Date() } });
-      }
-    }
-
+  updateUserOnlineStatus: async (root, { status }, { mongo: { Users }, user }) => {
+    const methodArgs = [{ _id: user._id, status }];
+    await callMethodAtEndpoint('updateUserOnlineStatus', { 'x-userid': user._id }, methodArgs);
     return await Users.findOne({ _id: user._id });
   },
 };

--- a/src/schema/user/schema.js
+++ b/src/schema/user/schema.js
@@ -22,6 +22,7 @@ User = `
     login(email: String!, password: String!): User
     updateUserLastWorkspace(workspace: String!): User
     updateUserTimezone(timezone: String!): User
+    # Updates the current user's online status
     updateUserOnlineStatus(status: UserStatusEnum!): User
   }
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] Make sure all new queries, mutations, subscriptions and fields have descriptions so others can understand their purpose
